### PR TITLE
fix: failing to clone from gopkg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://go.googlesource.com/net
 [submodule "src/gopkg.in/yaml.v2"]
 	path = src/gopkg.in/yaml.v2
-	url = https://gopkg.in/yaml.v2
+	url = https://github.com/go-yaml/yaml
 [submodule "src/golang.org/x/text"]
 	path = src/golang.org/x/text
 	url = https://go.googlesource.com/text


### PR DESCRIPTION
After pulling, you need to run this:
```
git submodule sync --recursive
```

This should fix this issue:
```
Cannot obtain refs from GitHub: cannot talk to GitHub: Get https://github.com/go-yaml/yaml.git/info/refs?service=git-upload-pack: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

It looks like it is a known issue: https://github.com/niemeyer/gopkg/issues/63

So this change sidesteps gopkg and clones from github directly.

Thanks to @markstokan for finding the gopkg issue!